### PR TITLE
Add tools to rerun GitHub Actions workflow jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A personal GitHub MCP server for Claude.ai with Google OAuth authentication. Dep
 - Google OAuth authentication (only your email allowed)
 - Landing page with tool documentation
 
-## Tools (15 total)
+## Tools (17 total)
 
 ### Repositories
 | Tool | Description |
@@ -41,6 +41,8 @@ A personal GitHub MCP server for Claude.ai with Google OAuth authentication. Dep
 | `list_workflow_runs` | List recent runs (filter by workflow, branch, status) |
 | `get_workflow_run` | Get run details (status, conclusion, commit) |
 | `list_workflow_run_jobs` | List jobs and steps for a run |
+| `rerun_workflow` | Rerun all jobs in a workflow run |
+| `rerun_failed_jobs` | Rerun only the failed jobs in a workflow run |
 
 ## Setup
 

--- a/src/github/tools.ts
+++ b/src/github/tools.ts
@@ -579,4 +579,54 @@ export const tools: Record<string, Tool> = {
       }));
     },
   },
+
+  rerun_workflow: {
+    name: "rerun_workflow",
+    description: "Rerun all jobs in a workflow run",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repo: { type: "string", description: "Repository name" },
+        run_id: { type: "number", description: "Workflow run ID" },
+      },
+      required: ["repo", "run_id"],
+    },
+    handler: async (args: any) => {
+      await octokit.actions.reRunWorkflow({
+        owner: config.githubOwner,
+        repo: args.repo,
+        run_id: args.run_id,
+      });
+      return {
+        success: true,
+        message: `Workflow run ${args.run_id} has been queued for rerun`,
+        run_id: args.run_id,
+      };
+    },
+  },
+
+  rerun_failed_jobs: {
+    name: "rerun_failed_jobs",
+    description: "Rerun only the failed jobs in a workflow run",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repo: { type: "string", description: "Repository name" },
+        run_id: { type: "number", description: "Workflow run ID" },
+      },
+      required: ["repo", "run_id"],
+    },
+    handler: async (args: any) => {
+      await octokit.actions.reRunWorkflowFailedJobs({
+        owner: config.githubOwner,
+        repo: args.repo,
+        run_id: args.run_id,
+      });
+      return {
+        success: true,
+        message: `Failed jobs in workflow run ${args.run_id} have been queued for rerun`,
+        run_id: args.run_id,
+      };
+    },
+  },
 };


### PR DESCRIPTION
Adds two new MCP tools for rerunning GitHub Actions workflow runs:

- `rerun_workflow` - Reruns all jobs in a workflow run
- `rerun_failed_jobs` - Reruns only the failed jobs in a workflow run

Both tools accept `repo` and `run_id` parameters.

Fixes #1

---
Generated with [Claude Code](https://claude.ai/code)