### PR TITLE
Add get_job_logs tool to fetch raw workflow job output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A personal GitHub MCP server for Claude.ai with Google OAuth authentication. Dep
 - Google OAuth authentication (only your email allowed)
 - Landing page with tool documentation
 
-## Tools (18 total)
+## Tools (19 total)
 
 ### Repositories
 | Tool | Description |
@@ -42,6 +42,7 @@ A personal GitHub MCP server for Claude.ai with Google OAuth authentication. Dep
 | `list_workflow_runs` | List recent runs (filter by workflow, branch, status) |
 | `get_workflow_run` | Get run details (status, conclusion, commit) |
 | `list_workflow_run_jobs` | List jobs and steps for a run |
+| `get_job_logs` | Get raw log output for a job (for debugging CI failures) |
 | `rerun_workflow` | Rerun all jobs in a workflow run |
 | `rerun_failed_jobs` | Rerun only the failed jobs in a workflow run |
 

--- a/src/github/tools.ts
+++ b/src/github/tools.ts
@@ -580,6 +580,30 @@ export const tools: Record<string, Tool> = {
     },
   },
 
+  get_job_logs: {
+    name: "get_job_logs",
+    description: "Get raw log output for a GitHub Actions job. Use this to debug CI failures.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repo: { type: "string", description: "Repository name" },
+        job_id: { type: "number", description: "Job ID from list_workflow_run_jobs" },
+      },
+      required: ["repo", "job_id"],
+    },
+    handler: async (args: any) => {
+      const response = await octokit.actions.downloadJobLogsForWorkflowRun({
+        owner: config.githubOwner,
+        repo: args.repo,
+        job_id: args.job_id,
+      });
+      return {
+        job_id: args.job_id,
+        logs: response.data,
+      };
+    },
+  },
+
   rerun_workflow: {
     name: "rerun_workflow",
     description: "Rerun all jobs in a workflow run",


### PR DESCRIPTION
Implements a new tool that fetches raw log output for GitHub Actions jobs, enabling debugging CI failures directly without visiting the GitHub UI.

## Changes
- Added `get_job_logs` tool in src/github/tools.ts
- Tool accepts `repo` name and `job_id` (from list_workflow_run_jobs)
- Returns raw log text using GitHub API endpoint
- Updated README with new tool count (19 total) and documentation

This completes the CI debugging workflow:
`list_workflow_runs` → `list_workflow_run_jobs` → `get_job_logs` → diagnose failure

Closes #5